### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/RebeccaAisbett2/79c750f3-ddc9-4fd0-9142-71e98b303453/5c0a1bcd-0254-498c-bee4-80ac27ad3f76/_apis/work/boardbadge/3549878b-4c8e-4a09-80f7-aa85f947f87a)](https://dev.azure.com/RebeccaAisbett2/79c750f3-ddc9-4fd0-9142-71e98b303453/_boards/board/t/5c0a1bcd-0254-498c-bee4-80ac27ad3f76/Microsoft.RequirementCategory)
 # Your GitHub Learning Lab Repository for Introducing GitHub
 
 Welcome to **your** repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through. See a word you don't understand? We've included an emoji 📖 next to some key terms. Click on it to see its definition.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/RebeccaAisbett2/79c750f3-ddc9-4fd0-9142-71e98b303453/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.